### PR TITLE
test deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
-name: Tests
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
 
-on: [push, pull_request]
+name: Tests
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,23 @@ jobs:
         # Enable this if using forking tests
         # env:
         #  ETH_RPC_URL: https://eth-mainnet.alchemyapi.io/v2/${{ secrets.ALCHEMY_API_KEY }}
+
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - uses: cachix/install-nix-action@v13
+      - uses: cachix/cachix-action@v10
+        with:
+          name: dapp
+
+      - name: Install dependencies
+        run: nix-shell --run 'make'
+
+      - name: Build the contracts
+        run: nix-shell --run 'make build'
+
+      - name: Deploy and run checks
+        run: nix-shell --run './scripts/test-deploy.sh'

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ make test
 Contracts can be deployed via the `make deploy` command. Addresses are automatically
 written in a name-address json file stored under `out/addresses.json`.
 
+We recommend testing your deployments and provide an example under [`scripts/test-deploy.sh`](./scripts/test-deploy.sh)
+which will launch a local testnet, deploy the contracts, and do some sanity checks.
+
 Environment variables under the `.env` file are automatically loaded (see [`.env.example`](./.env.example)).
 Be careful of the [precedence in which env vars are read](https://github.com/dapphub/dapptools/tree/2cf441052489625f8635bc69eb4842f0124f08e4/src/dapp#precedence).
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # All contracts are output to `out/addresses.json` by default
 OUT_DIR=${OUT_DIR:-$PWD/out}
 ADDRESSES_FILE=${ADDRESSES_FILE:-$OUT_DIR/"addresses.json"}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # import the deployment helpers
 . $(dirname $0)/common.sh
 

--- a/scripts/run-temp-testnet.sh
+++ b/scripts/run-temp-testnet.sh
@@ -1,0 +1,22 @@
+# Utility for running a temporary dapp testnet w/ an ephemeral account
+# to be used for deployment tests
+
+# clean up
+trap 'killall geth && rm -rf "$TMPDIR"' EXIT
+trap "exit 1" SIGINT SIGTERM
+
+# test helper
+error() {
+    printf 1>&2 "fail: function '%s' at line %d.\n" "${FUNCNAME[1]}"  "${BASH_LINENO[0]}"
+    printf 1>&2 "got: %s" "$output"
+    exit 1
+}
+
+# launch a testnet at a temp dir
+export TMPDIR=$(mktemp -d)
+dapp testnet --dir "$TMPDIR" &
+# wait for it to launch (can't go <3s)
+sleep 3
+
+# get the created account (it's unlocked so we only need to set the address)
+export ETH_FROM=$(seth ls --keystore $TMPDIR/8545/keystore | cut -f1)

--- a/scripts/run-temp-testnet.sh
+++ b/scripts/run-temp-testnet.sh
@@ -3,6 +3,9 @@
 # Utility for running a temporary dapp testnet w/ an ephemeral account
 # to be used for deployment tests
 
+# make a temp dir to store testnet info
+export TMPDIR=$(mktemp -d)
+
 # clean up
 trap 'killall geth && rm -rf "$TMPDIR"' EXIT
 trap "exit 1" SIGINT SIGTERM
@@ -14,8 +17,7 @@ error() {
     exit 1
 }
 
-# launch a testnet at a temp dir
-export TMPDIR=$(mktemp -d)
+# launch the testnet
 dapp testnet --dir "$TMPDIR" &
 # wait for it to launch (can't go <3s)
 sleep 3

--- a/scripts/run-temp-testnet.sh
+++ b/scripts/run-temp-testnet.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Utility for running a temporary dapp testnet w/ an ephemeral account
 # to be used for deployment tests
 

--- a/scripts/test-deploy.sh
+++ b/scripts/test-deploy.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # bring up the network
 . $(dirname $0)/run-temp-testnet.sh
 

--- a/scripts/test-deploy.sh
+++ b/scripts/test-deploy.sh
@@ -1,5 +1,4 @@
-# bring up the network
-. $(dirname $0)/run-temp-testnet.sh
+# bring up the network. $(dirname $0)/run-temp-testnet.sh
 
 # run the deploy script
 . $(dirname $0)/deploy.sh
@@ -10,8 +9,6 @@ addr=$(jq -r '.Greeter' out/addresses.json)
 # the initial greeting must be empty
 greeting=$(seth call $addr 'greeting()(string)')
 [[ $greeting = "" ]] || error
-
-# TODO: A bit annoying that we need to have quotes twice here.
 
 # set it to a value
 seth send $addr \

--- a/scripts/test-deploy.sh
+++ b/scripts/test-deploy.sh
@@ -1,4 +1,5 @@
-# bring up the network. $(dirname $0)/run-temp-testnet.sh
+# bring up the network
+. $(dirname $0)/run-temp-testnet.sh
 
 # run the deploy script
 . $(dirname $0)/deploy.sh

--- a/scripts/test-deploy.sh
+++ b/scripts/test-deploy.sh
@@ -1,0 +1,26 @@
+# bring up the network
+. $(dirname $0)/run-temp-testnet.sh
+
+# run the deploy script
+. $(dirname $0)/deploy.sh
+
+# get the address
+addr=$(jq -r '.Greeter' out/addresses.json)
+
+# the initial greeting must be empty
+greeting=$(seth call $addr 'greeting()(string)')
+[[ $greeting = "" ]] || error
+
+# TODO: A bit annoying that we need to have quotes twice here.
+
+# set it to a value
+seth send $addr \
+    'greet(string memory)' '"yo"' \
+    --keystore $TMPDIR/8545/keystore \
+    --password /dev/null
+
+sleep 1
+
+# should be set afterwards
+greeting=$(seth call $addr 'greeting()(string)')
+[[ $greeting = "yo" ]] || error

--- a/scripts/test-deploy.sh
+++ b/scripts/test-deploy.sh
@@ -24,3 +24,5 @@ sleep 1
 # should be set afterwards
 greeting=$(seth call $addr 'greeting()(string)')
 [[ $greeting = "yo" ]] || error
+
+echo "Success."

--- a/shell.nix
+++ b/shell.nix
@@ -11,5 +11,8 @@ in
     name = "dapptools-template";
     buildInputs = with pkgs; [
       pkgs.dapp
+      pkgs.seth
+      pkgs.go-ethereum-unlimited
+      pkgs.hevm
     ];
   }


### PR DESCRIPTION
adds scripts for testing deployments.
* `test-deploy.sh` runs `deploy.sh` and then proceeds to do some sanity checks
* `run-temp-testnet.sh` is used for running an ephemeral rpc testnet for testing the deploys