### PR TITLE
added random default block.timestamp to .dapprc

### DIFF
--- a/.dapprc
+++ b/.dapprc
@@ -7,6 +7,8 @@ export DAPP_BUILD_OPTIMIZE_RUNS=1000000
 export DAPP_LINK_TEST_LIBRARIES=0
 export DAPP_TEST_VERBOSITY=1
 export DAPP_TEST_SMTTIMEOUT=500000
+# random default block.timestamp for testing
+export DAPP_TIMESTAMP=1438269988
 
 # set so that we can deploy to local node w/o hosted private keys
 export ETH_RPC_ACCOUNTS=true

--- a/.dapprc
+++ b/.dapprc
@@ -8,7 +8,7 @@ export DAPP_LINK_TEST_LIBRARIES=0
 export DAPP_TEST_VERBOSITY=1
 export DAPP_TEST_SMTTIMEOUT=500000
 # random default block.timestamp for testing
-export DAPP_TIMESTAMP=1438269988
+export DAPP_TEST_TIMESTAMP=1438269988
 
 # set so that we can deploy to local node w/o hosted private keys
 export ETH_RPC_ACCOUNTS=true

--- a/src/test/utils/GreeterTest.sol
+++ b/src/test/utils/GreeterTest.sol
@@ -23,7 +23,7 @@ contract User {
 
 contract GreeterTest is DSTest {
     Hevm internal constant hevm =
-        Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+        Hevm(HEVM_ADDRESS);
 
     // contracts
     Greeter internal greeter;


### PR DESCRIPTION
hey,

really nice dapp.tools template. 💯 

I think it would be good to add a random default `block.timestamp` for testing.

Otherwise, it is zero by default which might introduce potential bugs during development. (edge case which will never occur on mainnet)


