### PR TITLE
feat: debug mode

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
+if [[ ${DEBUG} ]]; then
+    set -x
+fi
+
 # All contracts are output to `out/addresses.json` by default
 OUT_DIR=${OUT_DIR:-$PWD/out}
 ADDRESSES_FILE=${ADDRESSES_FILE:-$OUT_DIR/"addresses.json"}

--- a/scripts/contract-size.sh
+++ b/scripts/contract-size.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
 . $(dirname $0)/common.sh
 
 if [[ -z $contract ]]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 # import the deployment helpers
 . $(dirname $0)/common.sh
 

--- a/scripts/estimate-gas.sh
+++ b/scripts/estimate-gas.sh
@@ -1,3 +1,7 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
 . $(dirname $0)/common.sh
 
 if [[ -z $contract ]]; then

--- a/scripts/run-temp-testnet.sh
+++ b/scripts/run-temp-testnet.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 # Utility for running a temporary dapp testnet w/ an ephemeral account
 # to be used for deployment tests
 

--- a/scripts/test-deploy.sh
+++ b/scripts/test-deploy.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 # bring up the network
 . $(dirname $0)/run-temp-testnet.sh
 


### PR DESCRIPTION
sets flags that enforce stricter execution and helps avoid silent failures. see https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425

introduces a debug mode, running with `DEBUG=true`, e.g. `DEBUG=true make deploy-rinkeby`, will print all commands executed within the scripts to stdout

maybe it makes more sense to use `VERBOSE`?