### PR TITLE
feat: ensure ETH_FROM is checksummed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 
 # Dapptools
 out/
+.env

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -34,10 +34,16 @@ if [[ -z ${ETH_FROM} ]]; then
     exit 1
 fi
 
+# Make sure address is checksummed
+if [ $ETH_FROM != $(seth --to-checksum-address $ETH_FROM) ]; then
+    echo "ETH_FROM not checksummed, please format it with 'seth --to-checksum-address <address>'"
+    exit 1
+fi
+
 # Setup addresses file
 cat > "$ADDRESSES_FILE" <<EOF
 {
-    "DEPLOYER": "$(seth --to-checksum-address "$ETH_FROM")"
+    "DEPLOYER": "$ETH_FROM"
 }
 EOF
 


### PR DESCRIPTION
setting a unchecksummed address results in the `ethsign` lookup failing and the behavior defaults to using the node keystore. this updates the script to ensure the provided address is checksummed and valid.