### PR TITLE
chore: Update OZ remapping to support vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "solidity.packageDefaultDependenciesContractsDirectory": "src",
+  "solidity.packageDefaultDependenciesDirectory": "lib",
+  "files.associations": {
+    ".dapprc": "shellscript"
+  }
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
-@openzeppelin/=lib/openzeppelin-contracts/
+openzeppelin-contracts/=lib/openzeppelin-contracts/
 ds-test/=lib/ds-test/src/

--- a/src/Greeter.sol
+++ b/src/Greeter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
+import "openzeppelin-contracts/contracts/access/Ownable.sol";
 
 library Errors {
     string constant InvalidBlockNumber = "invalid block number, please wait";


### PR DESCRIPTION
vscode-solidity isn't aware of remappings and just looks in the lib directory with the path specified. matching the remapping name to the folder name like this fixes intellisense for vscode users

 would fix #15 if it was still open