### PR TITLE
ci: Run solc before update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # (-include to ignore error if it does not exist)
 -include .env
 
-install: update npm solc
+install: solc update npm
 
 # dapp deps
 update:; dapp update


### PR DESCRIPTION
In the current order we end up installing solc twice, first temporarily as part of `dapp update`, then permanently as part of the `solc` makefile script. Running the `solc` script first should cleanup the output and speed things up a bit.