### PR TITLE
add --recursive flag to git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Building and testing
 
 ```sh
-git clone https://github.com/gakonst/dapptools-template
+git clone --recursive https://github.com/gakonst/dapptools-template
 cd dapptools-template
 make
 make test


### PR DESCRIPTION
Without the flag, the `libs` directory will have the directories for the libs, but they will not be populated (i.e ds-test will be empty). user will have to `rm -rf` the dirs and `dapp install` the libs individually.