### PR TITLE
Added abstract keyword to GreeterTest

### DIFF
--- a/src/test/utils/GreeterTest.sol
+++ b/src/test/utils/GreeterTest.sol
@@ -21,7 +21,7 @@ contract User {
     }
 }
 
-contract GreeterTest is DSTest {
+abstract contract GreeterTest is DSTest {
     Hevm internal constant hevm = Hevm(HEVM_ADDRESS);
 
     // contracts


### PR DESCRIPTION
`GreeterTest` is never actually instantiated, it's only being inherited by the contracts in the `.t.sol` files. As such we can mark the contract as `abstract`