### PR TITLE
docs: Helpful tip in dapprc

### DIFF
--- a/.dapprc
+++ b/.dapprc
@@ -2,6 +2,7 @@
 export DAPP_REMAPPINGS=$(cat remappings.txt)
 
 export DAPP_SOLC_VERSION=0.8.7
+# If you're getting an "invalid character at offset" error, comment this out.
 export DAPP_LINK_TEST_LIBRARIES=0
 export DAPP_TEST_VERBOSITY=1
 export DAPP_TEST_SMTTIMEOUT=500000


### PR DESCRIPTION
I think its worth having this flag on by default or else people will hate the slow builds, but without this comment a lot of people get stuck hehe