### PR TITLE
fix: fetch contract ABI correctly during deployment

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -58,8 +58,12 @@ EOF
 deploy() {
 	NAME=$1
 	ARGS=${@:2}
+
+    CONTRACT_PATH=$(find . | grep $NAME.sol)
+    CONTRACT_PATH=${CONTRACT_PATH:2}
+
 	# select the filename and the contract in it
-	PATTERN=".contracts[\"src/$NAME.sol\"].$NAME"
+	PATTERN=".contracts[\"$CONTRACT_PATH\"].$NAME"
 
 	# get the constructor's signature
 	ABI=$(jq -r "$PATTERN.abi" out/dapp.sol.json)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -59,15 +59,12 @@ deploy() {
 	NAME=$1
 	ARGS=${@:2}
 
+    # find file path
     CONTRACT_PATH=$(find -name $NAME.sol)
     CONTRACT_PATH=${CONTRACT_PATH:2}
 
-    echo "PATH: $CONTRACT_PATH"
-
 	# select the filename and the contract in it
 	PATTERN=".contracts[\"$CONTRACT_PATH\"].$NAME"
-
-    echo "PATTERN: $PATTERN"
 
 	# get the constructor's signature
 	ABI=$(jq -r "$PATTERN.abi" out/dapp.sol.json)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -59,11 +59,15 @@ deploy() {
 	NAME=$1
 	ARGS=${@:2}
 
-    CONTRACT_PATH=$(find . | grep $NAME.sol)
+    CONTRACT_PATH=$(find -name $NAME.sol)
     CONTRACT_PATH=${CONTRACT_PATH:2}
+
+    echo "PATH: $CONTRACT_PATH"
 
 	# select the filename and the contract in it
 	PATTERN=".contracts[\"$CONTRACT_PATH\"].$NAME"
+
+    echo "PATTERN: $PATTERN"
 
 	# get the constructor's signature
 	ABI=$(jq -r "$PATTERN.abi" out/dapp.sol.json)

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -60,8 +60,8 @@ deploy() {
 	ARGS=${@:2}
 
     # find file path
-    CONTRACT_PATH=$(find -name $NAME.sol)
-    CONTRACT_PATH=${CONTRACT_PATH:2}
+	CONTRACT_PATH=$(find -name $NAME.sol)
+	CONTRACT_PATH=${CONTRACT_PATH:2}
 
 	# select the filename and the contract in it
 	PATTERN=".contracts[\"$CONTRACT_PATH\"].$NAME"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -59,7 +59,7 @@ deploy() {
 	NAME=$1
 	ARGS=${@:2}
 
-    # find file path
+	# find file path
 	CONTRACT_PATH=$(find -name $NAME.sol)
 	CONTRACT_PATH=${CONTRACT_PATH:2}
 


### PR DESCRIPTION
If you write a contract inside a nested folder of src, the gas estimation fails, leading to failed deployments. This is because the script searches for the contact ABI in `dapp.sol.json` with the assumption that the contract is stored at `src/contractName`. I wrote up a quick fix using the `find` command to dynamically get the file path instead.